### PR TITLE
Disambiguate dev docs from the user docs

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to snipe's documentation!
-=================================
+Welcome to snipe's developer documentation!
+===========================================
 
 Contents:
 


### PR DESCRIPTION
Trivial change, but I think a slight improvement?